### PR TITLE
Support glob patterns in import_r2ka

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ python app/build_database.py CSVディレクトリ 出力.db
 ### R2KA CSV の取り込み
 
 ```bash
-python app/import_r2ka.py 出力.db r2ka1.csv r2ka2.csv
+python app/import_r2ka.py 出力.db ./data/*.csv
 ```
 =======
 - `src/` - common source code

--- a/app/import_r2ka.py
+++ b/app/import_r2ka.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+import glob
 
 from src.r2ka_importer import R2KAImporter
 
@@ -15,16 +16,20 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "csv_files",
         nargs="+",
-        type=Path,
-        help="R2KA CSV files encoded in SJIS",
+        type=str,
+        help="R2KA CSV files encoded in SJIS or glob patterns",
     )
     return parser.parse_args()
 
 
 def main() -> None:
     args = parse_args()
+    paths = []
+    for pattern in args.csv_files:
+        matches = glob.glob(pattern)
+        paths.extend(matches if matches else [pattern])
     importer = R2KAImporter(db_path=str(args.db_path))
-    attempted, inserted = importer.import_csvs([str(p) for p in args.csv_files])
+    attempted, inserted = importer.import_csvs(paths)
     print(f"Processed {attempted} rows, inserted {inserted} new records.")
     print(f"Database saved to {args.db_path}")
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -13,7 +13,7 @@ python app/build_database.py CSVディレクトリ 出力先.db
 ### R2KA CSV を取り込む場合
 
 ```bash
-python app/import_r2ka.py 出力.db r2ka1.csv r2ka2.csv
+python app/import_r2ka.py 出力.db ./data/*.csv
 ```
 
 CSV は SJIS (cp932) でエンコードされている想定です。処理後、データベース内には UTF-8 として保存されます。


### PR DESCRIPTION
## Summary
- allow `app/import_r2ka.py` to expand glob patterns
- document wildcard usage in the README files

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684636578934832bab635dacb7d43e03