### PR TITLE
Fix CLI module imports

### DIFF
--- a/app/build_database.py
+++ b/app/build_database.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 from src.csv_to_sqlite import CsvToSqliteConverter
 

--- a/app/import_r2ka.py
+++ b/app/import_r2ka.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 import glob
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 from src.r2ka_importer import R2KAImporter
 


### PR DESCRIPTION
## Summary
- ensure CLI scripts can locate `src` when executed from any directory

## Testing
- `python -m py_compile app/import_r2ka.py app/build_database.py src/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846734aff50832ba49cd1a50590ffe2