### PR TITLE
Add invalid record handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,5 @@ python app/build_database.py CSVディレクトリ 出力.db
 python app/import_r2ka.py 出力.db ./data/*.{csv,dbf}
 ```
 
+もし CSV 内に登録できないレコードが含まれている場合は、その内容を表示して処理を中断します。
+

--- a/app/import_r2ka.py
+++ b/app/import_r2ka.py
@@ -33,7 +33,11 @@ def main() -> None:
         matches = glob.glob(pattern)
         paths.extend(matches if matches else [pattern])
     importer = R2KAImporter(db_path=str(args.db_path))
-    attempted, inserted = importer.import_csvs(paths)
+    try:
+        attempted, inserted = importer.import_csvs(paths)
+    except ValueError as e:
+        print(e)
+        sys.exit(1)
     print(f"Processed {attempted} rows, inserted {inserted} new records.")
     print(f"Database saved to {args.db_path}")
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -17,4 +17,6 @@ python app/build_database.py CSVディレクトリ 出力先.db
 python app/import_r2ka.py 出力.db ./data/*.{csv,dbf}
 ```
 
+CSV 内に登録できないレコードが見つかった場合、その行を表示して処理を終了します。
+
 CSV は SJIS (cp932) でエンコードされている想定です。処理後、データベース内には UTF-8 として保存されます。

--- a/src/r2ka_importer.py
+++ b/src/r2ka_importer.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 from typing import Dict, Iterable, Tuple, List
-import logging
 import re
 
 import csv
@@ -107,8 +106,7 @@ class R2KAImporter:
                     city_code = self._parse_numeric_code(row["CITY"], 3)
                     s_area_code = self._parse_numeric_code(row["S_AREA"], 6)
                 except ValueError as e:
-                    logging.warning("Skipping row due to invalid code: %s", e)
-                    continue
+                    raise ValueError(f"Invalid record {row}: {e}") from e
 
                 pref_name = row["PREF_NAME"].strip()
                 city_name = row["CITY_NAME"].strip()


### PR DESCRIPTION
## Summary
- abort import when encountering invalid records
- update `import_r2ka.py` CLI to print the invalid row and exit
- document new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846c72e53a4832b8b30e48b60493b4c