### PR TITLE
Add CityIdSelector for city lookup

### DIFF
--- a/sample/lookup_city.py
+++ b/sample/lookup_city.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Example script to look up city_id by codes."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+from src.r2ka_api import CityIdSelector
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Lookup city_id")
+    parser.add_argument("db_path", type=Path, help="SQLite database path")
+    parser.add_argument("pref_code", type=int, help="Prefecture code")
+    parser.add_argument("city_code", type=int, help="City code")
+    args = parser.parse_args()
+
+    with CityIdSelector(args.db_path) as selector:
+        city_id = selector.get_city_id(args.pref_code, args.city_code)
+        if city_id is None:
+            print("Not found")
+        else:
+            print(city_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/sample/lookup_sub_area.py
+++ b/sample/lookup_sub_area.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Example script to look up sub_area_id by codes."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+from src.r2ka_api import SubAreaIdSelector
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Lookup sub_area_id")
+    parser.add_argument("db_path", type=Path, help="SQLite database path")
+    parser.add_argument("pref_code", type=int, help="Prefecture code")
+    parser.add_argument("city_code", type=int, help="City code")
+    parser.add_argument("s_area_code", type=int, help="Sub area code")
+    args = parser.parse_args()
+
+    with SubAreaIdSelector(args.db_path) as selector:
+        sub_area_id = selector.get_sub_area_id(
+            args.pref_code, args.city_code, args.s_area_code
+        )
+        if sub_area_id is None:
+            print("Not found")
+        else:
+            print(sub_area_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/r2ka_api.py
+++ b/src/r2ka_api.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+
+def get_city_id(db_path: str | Path, pref_code: int, city_code: int) -> Optional[int]:
+    """Return city_id for given prefecture and city codes or None."""
+    query = (
+        "SELECT city_id FROM cities "
+        "WHERE pref_code = ? AND city_code = ? "
+        "LIMIT 1"
+    )
+    with sqlite3.connect(str(db_path)) as conn:
+        cur = conn.execute(query, (pref_code, city_code))
+        row = cur.fetchone()
+    return int(row[0]) if row else None
+
+
+def get_sub_area_id(
+    db_path: str | Path,
+    pref_code: int,
+    city_code: int,
+    s_area_code: int,
+) -> Optional[int]:
+    """Return sub_area_id for given codes or None if not found."""
+    query = (
+        "SELECT sa.sub_area_id "
+        "FROM sub_areas sa "
+        "JOIN cities c ON sa.city_id = c.city_id "
+        "JOIN prefectures p ON sa.prefecture_id = p.prefecture_id "
+        "WHERE p.pref_code = ? AND c.city_code = ? AND sa.s_area_code = ? "
+        "LIMIT 1"
+    )
+    with sqlite3.connect(str(db_path)) as conn:
+        cur = conn.execute(query, (pref_code, city_code, s_area_code))
+        row = cur.fetchone()
+    return int(row[0]) if row else None
+
+
+class SubAreaIdSelector:
+    """Cache-aware helper for looking up ``sub_area_id`` values."""
+
+    def __init__(self, db_path: str | Path) -> None:
+        self.db_path = Path(db_path)
+        self._conn = sqlite3.connect(str(self.db_path))
+        self._cache: Dict[Tuple[int, int, int], Optional[int]] = {}
+
+    def close(self) -> None:
+        if self._conn:
+            self._conn.close()
+
+    def __enter__(self) -> "SubAreaIdSelector":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def get_sub_area_id(
+        self, pref_code: int, city_code: int, s_area_code: int
+    ) -> Optional[int]:
+        key = (pref_code, city_code, s_area_code)
+        if key in self._cache:
+            return self._cache[key]
+
+        query = (
+            "SELECT sa.sub_area_id "
+            "FROM sub_areas sa "
+            "JOIN cities c ON sa.city_id = c.city_id "
+            "JOIN prefectures p ON sa.prefecture_id = p.prefecture_id "
+            "WHERE p.pref_code = ? AND c.city_code = ? AND sa.s_area_code = ? "
+            "LIMIT 1"
+        )
+        cur = self._conn.execute(query, key)
+        row = cur.fetchone()
+        result = int(row[0]) if row else None
+        self._cache[key] = result
+        return result
+
+
+class CityIdSelector:
+    """Cache-aware helper for looking up ``city_id`` values."""
+
+    def __init__(self, db_path: str | Path) -> None:
+        self.db_path = Path(db_path)
+        self._conn = sqlite3.connect(str(self.db_path))
+        self._cache: Dict[Tuple[int, int], Optional[int]] = {}
+
+    def close(self) -> None:
+        if self._conn:
+            self._conn.close()
+
+    def __enter__(self) -> "CityIdSelector":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def get_city_id(self, pref_code: int, city_code: int) -> Optional[int]:
+        key = (pref_code, city_code)
+        if key in self._cache:
+            return self._cache[key]
+
+        query = (
+            "SELECT city_id FROM cities "
+            "WHERE pref_code = ? AND city_code = ? "
+            "LIMIT 1"
+        )
+        cur = self._conn.execute(query, key)
+        row = cur.fetchone()
+        result = int(row[0]) if row else None
+        self._cache[key] = result
+        return result
+
+
+__all__ = [
+    "get_city_id",
+    "CityIdSelector",
+    "get_sub_area_id",
+    "SubAreaIdSelector",
+]
+

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,63 @@
+import sqlite3
+import tempfile
+from pathlib import Path
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+from src.r2ka_importer import R2KAImporter
+from src.r2ka_api import CityIdSelector, SubAreaIdSelector
+
+
+def test_get_sub_area_id():
+    dbf_path = Path('dev/r2ka11.dbf')
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / 'out.db'
+        importer = R2KAImporter(db_path=str(db_path))
+        importer.import_csvs([str(dbf_path)])
+
+        selector = SubAreaIdSelector(db_path)
+
+        # Known record from sample data
+        sub_id = selector.get_sub_area_id(11, 101, 1000)
+        assert sub_id is not None
+
+        # second call should hit cache and not query database again
+        class DummyConn:
+            def execute(self, *args, **kwargs):
+                raise RuntimeError("db queried")
+
+        selector._conn = DummyConn()
+        again = selector.get_sub_area_id(11, 101, 1000)
+        assert again == sub_id
+
+        selector._conn = sqlite3.connect(str(db_path))
+        missing = selector.get_sub_area_id(99, 999, 999999)
+        assert missing is None
+
+
+def test_get_city_id():
+    dbf_path = Path('dev/r2ka11.dbf')
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / 'out.db'
+        importer = R2KAImporter(db_path=str(db_path))
+        importer.import_csvs([str(dbf_path)])
+
+        selector = CityIdSelector(db_path)
+
+        # Known record from sample data
+        city_id = selector.get_city_id(11, 101)
+        assert city_id is not None
+
+        class DummyConn:
+            def execute(self, *args, **kwargs):
+                raise RuntimeError('db queried')
+
+        selector._conn = DummyConn()
+        again = selector.get_city_id(11, 101)
+        assert again == city_id
+
+        selector._conn = sqlite3.connect(str(db_path))
+        missing = selector.get_city_id(99, 999)
+        assert missing is None


### PR DESCRIPTION
## Summary
- add `get_city_id` API to fetch `city_id` from prefecture and city codes
- implement `CityIdSelector` class with caching
- provide `lookup_city.py` sample script
- test `CityIdSelector` alongside existing API

## Testing
- `pip install dbfread pandas`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a62a99a38832bafe2012792ae6edb