### PR TITLE
Add shared database API with pagination

### DIFF
--- a/app/import_r2ka.py
+++ b/app/import_r2ka.py
@@ -9,6 +9,7 @@ import sys
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
+from src.database import Database
 from src.r2ka_importer import R2KAImporter
 
 
@@ -32,14 +33,15 @@ def main() -> None:
     for pattern in args.csv_files:
         matches = glob.glob(pattern)
         paths.extend(matches if matches else [pattern])
-    importer = R2KAImporter(db_path=str(args.db_path))
-    try:
-        attempted, inserted = importer.import_csvs(paths)
-    except ValueError as e:
-        print(e)
-        sys.exit(1)
-    print(f"Processed {attempted} rows, inserted {inserted} new records.")
-    print(f"Database saved to {args.db_path}")
+    with Database(args.db_path) as db:
+        importer = R2KAImporter(db)
+        try:
+            attempted, inserted = importer.import_csvs(paths)
+        except ValueError as e:
+            print(e)
+            sys.exit(1)
+        print(f"Processed {attempted} rows, inserted {inserted} new records.")
+        print(f"Database saved to {args.db_path}")
 
 
 if __name__ == "__main__":

--- a/sample/lookup_city.py
+++ b/sample/lookup_city.py
@@ -10,6 +10,7 @@ import sys
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
+from src.database import Database
 from src.r2ka_api import CityIdSelector
 
 
@@ -20,7 +21,8 @@ def main() -> None:
     parser.add_argument("city_code", type=int, help="City code")
     args = parser.parse_args()
 
-    with CityIdSelector(args.db_path) as selector:
+    with Database(args.db_path) as db:
+        selector = CityIdSelector(db)
         city_id = selector.get_city_id(args.pref_code, args.city_code)
         if city_id is None:
             print("Not found")

--- a/sample/lookup_sub_area.py
+++ b/sample/lookup_sub_area.py
@@ -10,6 +10,7 @@ import sys
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
+from src.database import Database
 from src.r2ka_api import SubAreaIdSelector
 
 
@@ -21,7 +22,8 @@ def main() -> None:
     parser.add_argument("s_area_code", type=int, help="Sub area code")
     args = parser.parse_args()
 
-    with SubAreaIdSelector(args.db_path) as selector:
+    with Database(args.db_path) as db:
+        selector = SubAreaIdSelector(db)
         sub_area_id = selector.get_sub_area_id(
             args.pref_code, args.city_code, args.s_area_code
         )

--- a/sample/read_cities.py
+++ b/sample/read_cities.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import sqlite3
 from pathlib import Path
 from typing import Dict, Tuple
 import os
@@ -12,11 +11,13 @@ import sys
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
+from src.database import Database
+
 def load_city_mapping(db_path: Path) -> Dict[int, Tuple[int, int]]:
     """Return a mapping from city_id to (pref_code, city_code)."""
     mapping: Dict[int, Tuple[int, int]] = {}
-    with sqlite3.connect(db_path) as conn:
-        cur = conn.cursor()
+    with Database(db_path) as db:
+        cur = db.conn.cursor()
         for row in cur.execute(
             "SELECT city_id, pref_code, city_code FROM cities ORDER BY city_id"
         ):

--- a/src/database.py
+++ b/src/database.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+
+class Database:
+    """Simple wrapper around :class:`sqlite3.Connection`."""
+
+    def __init__(self, db_path: str | Path) -> None:
+        self.path = Path(db_path)
+        self.conn = sqlite3.connect(str(self.path))
+
+    def close(self) -> None:
+        if self.conn:
+            self.conn.close()
+
+    def __enter__(self) -> "Database":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+
+__all__ = ["Database"]

--- a/src/r2ka_importer.py
+++ b/src/r2ka_importer.py
@@ -1,20 +1,20 @@
 from __future__ import annotations
 
 import sqlite3
-from pathlib import Path
 from typing import Dict, Iterable, Tuple, List
 import re
 from collections import defaultdict
 
 import csv
 from dbfread import DBF
+from .database import Database
 
 
 class R2KAImporter:
     """Import records from one or more CSV files into a normalized SQLite database."""
 
-    def __init__(self, db_path: str) -> None:
-        self.db_path = Path(db_path)
+    def __init__(self, db: Database) -> None:
+        self.db = db
 
     def _create_schema(self, conn: sqlite3.Connection) -> None:
         cur = conn.cursor()
@@ -132,100 +132,100 @@ class R2KAImporter:
                 )
                 attempted += 1
 
-        with sqlite3.connect(self.db_path) as conn:
-            self._create_schema(conn)
-            cur = conn.cursor()
+        conn = self.db.conn
+        self._create_schema(conn)
+        cur = conn.cursor()
 
-            cur.execute("SELECT pref_code, prefecture_id FROM prefectures")
-            pref_cache: Dict[int, int] = {code: pid for code, pid in cur.fetchall()}
+        cur.execute("SELECT pref_code, prefecture_id FROM prefectures")
+        pref_cache: Dict[int, int] = {code: pid for code, pid in cur.fetchall()}
 
-            cur.execute("SELECT pref_code, city_code, city_id FROM cities")
-            city_cache: Dict[Tuple[int, int], int] = {(p, c): cid for p, c, cid in cur.fetchall()}
+        cur.execute("SELECT pref_code, city_code, city_id FROM cities")
+        city_cache: Dict[Tuple[int, int], int] = {(p, c): cid for p, c, cid in cur.fetchall()}
 
-            cur.execute("SELECT area_name, area_id FROM areas")
-            area_cache: Dict[str, int] = {n: aid for n, aid in cur.fetchall()}
+        cur.execute("SELECT area_name, area_id FROM areas")
+        area_cache: Dict[str, int] = {n: aid for n, aid in cur.fetchall()}
 
-            cur.execute("SELECT section_name, section_id FROM sections")
-            section_cache: Dict[str, int] = {n: sid for n, sid in cur.fetchall()}
+        cur.execute("SELECT section_name, section_id FROM sections")
+        section_cache: Dict[str, int] = {n: sid for n, sid in cur.fetchall()}
 
-            cur.execute("SELECT s_area_code, city_id, prefecture_id FROM sub_areas")
-            sub_area_cache: Dict[Tuple[int, int, int], int] = {(s, cid, pid): 1 for s, cid, pid in cur.fetchall()}
+        cur.execute("SELECT s_area_code, city_id, prefecture_id FROM sub_areas")
+        sub_area_cache: Dict[Tuple[int, int, int], int] = {(s, cid, pid): 1 for s, cid, pid in cur.fetchall()}
 
-            grouped: Dict[Tuple[int, int, int], List[Tuple[int, int, int, str, str, str]]] = defaultdict(list)
-            for rec in records:
-                area_code = rec[2] // 100
-                grouped[(rec[0], rec[1], area_code)].append(rec)
+        grouped: Dict[Tuple[int, int, int], List[Tuple[int, int, int, str, str, str]]] = defaultdict(list)
+        for rec in records:
+            area_code = rec[2] // 100
+            grouped[(rec[0], rec[1], area_code)].append(rec)
 
-            for key, recs in grouped.items():
-                names = [r[5] for r in recs]
-                prefix = self._longest_common_prefix(names).strip()
+        for key, recs in grouped.items():
+            names = [r[5] for r in recs]
+            prefix = self._longest_common_prefix(names).strip()
 
-                for pref_code, city_code, s_area_code, pref_name, city_name, s_name in recs:
-                    if pref_code not in pref_cache:
-                        cur.execute(
-                            "INSERT INTO prefectures (pref_code, pref_name) VALUES (?, ?)",
-                            (pref_code, pref_name),
-                        )
-                        pref_cache[pref_code] = cur.lastrowid
-                    pref_id = pref_cache[pref_code]
+            for pref_code, city_code, s_area_code, pref_name, city_name, s_name in recs:
+                if pref_code not in pref_cache:
+                    cur.execute(
+                        "INSERT INTO prefectures (pref_code, pref_name) VALUES (?, ?)",
+                        (pref_code, pref_name),
+                    )
+                    pref_cache[pref_code] = cur.lastrowid
+                pref_id = pref_cache[pref_code]
 
-                    city_key = (pref_code, city_code)
-                    if city_key not in city_cache:
-                        cur.execute(
-                            "INSERT INTO cities (pref_code, city_code, city_name) VALUES (?, ?, ?)",
-                            (pref_code, city_code, city_name),
-                        )
-                        city_cache[city_key] = cur.lastrowid
-                    city_id = city_cache[city_key]
+                city_key = (pref_code, city_code)
+                if city_key not in city_cache:
+                    cur.execute(
+                        "INSERT INTO cities (pref_code, city_code, city_name) VALUES (?, ?, ?)",
+                        (pref_code, city_code, city_name),
+                    )
+                    city_cache[city_key] = cur.lastrowid
+                city_id = city_cache[city_key]
 
-                    section_code = s_area_code % 100
+                section_code = s_area_code % 100
 
-                    if prefix:
-                        area_name = prefix
-                        if section_code == 0:
-                            section_name = None
-                        else:
-                            remainder = s_name[len(prefix):].strip()
-                            section_name = remainder or None
+                if prefix:
+                    area_name = prefix
+                    if section_code == 0:
+                        section_name = None
                     else:
-                        if section_code == 0:
+                        remainder = s_name[len(prefix):].strip()
+                        section_name = remainder or None
+                else:
+                    if section_code == 0:
+                        area_name = s_name
+                        section_name = None
+                    else:
+                        m = re.search(r"([一二三四五六七八九十百]+丁目)$", s_name)
+                        if m:
+                            area_name = s_name[: -len(m.group(1))]
+                            section_name = m.group(1)
+                        else:
                             area_name = s_name
                             section_name = None
-                        else:
-                            m = re.search(r"([一二三四五六七八九十百]+丁目)$", s_name)
-                            if m:
-                                area_name = s_name[: -len(m.group(1))]
-                                section_name = m.group(1)
-                            else:
-                                area_name = s_name
-                                section_name = None
 
-                    if area_name not in area_cache:
-                        cur.execute("INSERT INTO areas (area_name) VALUES (?)", (area_name,))
-                        area_cache[area_name] = cur.lastrowid
-                    area_id = area_cache[area_name]
+                if area_name not in area_cache:
+                    cur.execute("INSERT INTO areas (area_name) VALUES (?)", (area_name,))
+                    area_cache[area_name] = cur.lastrowid
+                area_id = area_cache[area_name]
 
-                    if section_name is not None:
-                        if section_name not in section_cache:
-                            cur.execute(
-                                "INSERT INTO sections (section_name) VALUES (?)",
-                                (section_name,),
-                            )
-                            section_cache[section_name] = cur.lastrowid
-                        section_id = section_cache[section_name]
-                    else:
-                        section_id = None
-
-                    sub_key = (s_area_code, city_id, pref_id)
-                    if sub_key not in sub_area_cache:
+                if section_name is not None:
+                    if section_name not in section_cache:
                         cur.execute(
-                            "INSERT INTO sub_areas (s_area_code, area_id, section_id, city_id, prefecture_id) VALUES (?, ?, ?, ?, ?)",
-                            (s_area_code, area_id, section_id, city_id, pref_id),
+                            "INSERT INTO sections (section_name) VALUES (?)",
+                            (section_name,),
                         )
-                        sub_area_cache[sub_key] = 1
-                        inserted += 1
+                        section_cache[section_name] = cur.lastrowid
+                    section_id = section_cache[section_name]
+                else:
+                    section_id = None
 
-            conn.commit()
+                sub_key = (s_area_code, city_id, pref_id)
+                if sub_key not in sub_area_cache:
+                    cur.execute(
+                        "INSERT INTO sub_areas (s_area_code, area_id, section_id, city_id, prefecture_id) VALUES (?, ?, ?, ?, ?)",
+                        (s_area_code, area_id, section_id, city_id, pref_id),
+                    )
+                    sub_area_cache[sub_key] = 1
+                    inserted += 1
+
+        conn.commit()
 
         return attempted, inserted
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,58 +6,75 @@ import sys
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
+from src.database import Database
 from src.r2ka_importer import R2KAImporter
-from src.r2ka_api import CityIdSelector, SubAreaIdSelector
+from src.r2ka_api import CityIdSelector, SubAreaIdSelector, SubAreaReader
 
 
 def test_get_sub_area_id():
     dbf_path = Path('dev/r2ka11.dbf')
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = Path(tmpdir) / 'out.db'
-        importer = R2KAImporter(db_path=str(db_path))
-        importer.import_csvs([str(dbf_path)])
+        with Database(db_path) as db:
+            importer = R2KAImporter(db)
+            importer.import_csvs([str(dbf_path)])
 
-        selector = SubAreaIdSelector(db_path)
+            selector = SubAreaIdSelector(db)
 
-        # Known record from sample data
-        sub_id = selector.get_sub_area_id(11, 101, 1000)
-        assert sub_id is not None
+            # Known record from sample data
+            sub_id = selector.get_sub_area_id(11, 101, 1000)
+            assert sub_id is not None
 
-        # second call should hit cache and not query database again
-        class DummyConn:
-            def execute(self, *args, **kwargs):
-                raise RuntimeError("db queried")
+            # second call should hit cache and not query database again
+            class DummyConn:
+                def execute(self, *args, **kwargs):
+                    raise RuntimeError("db queried")
 
-        selector._conn = DummyConn()
-        again = selector.get_sub_area_id(11, 101, 1000)
-        assert again == sub_id
+            selector._conn = DummyConn()
+            again = selector.get_sub_area_id(11, 101, 1000)
+            assert again == sub_id
 
-        selector._conn = sqlite3.connect(str(db_path))
-        missing = selector.get_sub_area_id(99, 999, 999999)
-        assert missing is None
+            selector._conn = sqlite3.connect(str(db_path))
+            missing = selector.get_sub_area_id(99, 999, 999999)
+            assert missing is None
 
 
 def test_get_city_id():
     dbf_path = Path('dev/r2ka11.dbf')
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = Path(tmpdir) / 'out.db'
-        importer = R2KAImporter(db_path=str(db_path))
-        importer.import_csvs([str(dbf_path)])
+        with Database(db_path) as db:
+            importer = R2KAImporter(db)
+            importer.import_csvs([str(dbf_path)])
 
-        selector = CityIdSelector(db_path)
+            selector = CityIdSelector(db)
 
-        # Known record from sample data
-        city_id = selector.get_city_id(11, 101)
-        assert city_id is not None
+            # Known record from sample data
+            city_id = selector.get_city_id(11, 101)
+            assert city_id is not None
 
-        class DummyConn:
-            def execute(self, *args, **kwargs):
-                raise RuntimeError('db queried')
+            class DummyConn:
+                def execute(self, *args, **kwargs):
+                    raise RuntimeError('db queried')
 
-        selector._conn = DummyConn()
-        again = selector.get_city_id(11, 101)
-        assert again == city_id
+            selector._conn = DummyConn()
+            again = selector.get_city_id(11, 101)
+            assert again == city_id
 
-        selector._conn = sqlite3.connect(str(db_path))
-        missing = selector.get_city_id(99, 999)
-        assert missing is None
+            selector._conn = sqlite3.connect(str(db_path))
+            missing = selector.get_city_id(99, 999)
+            assert missing is None
+
+def test_sub_area_reader():
+    dbf_path = Path('dev/r2ka11.dbf')
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / 'out.db'
+        with Database(db_path) as db:
+            importer = R2KAImporter(db)
+            importer.import_csvs([str(dbf_path)])
+
+            reader = SubAreaReader(db)
+            total, rows = reader.fetch(0, 5)
+            assert total > 0
+            assert 0 < len(rows) <= 5
+            assert all('sub_area_id' in r for r in rows)


### PR DESCRIPTION
## Summary
- add `Database` wrapper for a shared connection
- update `R2KAImporter`, `CityIdSelector`, and `SubAreaIdSelector` to take a `Database`
- implement `SubAreaReader` for total count and ranged record retrieval
- adjust command-line apps and samples for the new API
- update tests for new interfaces and add coverage for `SubAreaReader`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b8c083c24832ba2ae385bcbec9e13