### PR TITLE
Add encoding option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,8 @@ python app/build_database.py CSVディレクトリ 出力.db
 python app/import_r2ka.py 出力.db ./data/*.{csv,dbf}
 ```
 
+`--encoding` オプションで CSV/DBF ファイルの文字コードを指定できます。既定値は
+`cp932` です。
+
 もし CSV 内に登録できないレコードが含まれている場合は、その内容を表示して処理を中断します。
 

--- a/app/import_r2ka.py
+++ b/app/import_r2ka.py
@@ -24,6 +24,11 @@ def parse_args() -> argparse.Namespace:
         type=str,
         help="R2KA CSV or DBF files encoded in SJIS or glob patterns",
     )
+    parser.add_argument(
+        "--encoding",
+        default="cp932",
+        help="File encoding for input CSV/DBF (default: cp932)",
+    )
     return parser.parse_args()
 
 
@@ -34,7 +39,7 @@ def main() -> None:
         matches = glob.glob(pattern)
         paths.extend(matches if matches else [pattern])
     with Database(args.db_path) as db:
-        importer = R2KAImporter(db)
+        importer = R2KAImporter(db, encoding=args.encoding)
         try:
             attempted, inserted = importer.import_csvs(paths)
         except ValueError as e:

--- a/doc/README.md
+++ b/doc/README.md
@@ -17,6 +17,9 @@ python app/build_database.py CSVディレクトリ 出力先.db
 python app/import_r2ka.py 出力.db ./data/*.{csv,dbf}
 ```
 
+`--encoding` オプションで CSV/DBF ファイルの文字コードを指定可能です。既定値は
+`cp932` となります。
+
 CSV 内に登録できないレコードが見つかった場合、その行を表示して処理を終了します。
 
 CSV は SJIS (cp932) でエンコードされている想定です。処理後、データベース内には UTF-8 として保存されます。

--- a/estat_shp_utils/r2ka_importer.py
+++ b/estat_shp_utils/r2ka_importer.py
@@ -13,8 +13,9 @@ from .database import Database
 class R2KAImporter:
     """Import records from one or more CSV files into a normalized SQLite database."""
 
-    def __init__(self, db: Database) -> None:
+    def __init__(self, db: Database, encoding: str = "cp932") -> None:
         self.db = db
+        self.encoding = encoding
 
     def _create_schema(self, conn: sqlite3.Connection) -> None:
         cur = conn.cursor()
@@ -97,11 +98,11 @@ class R2KAImporter:
     def _iter_records(self, path: str) -> Iterable[dict[str, str]]:
         """Yield records from a CSV or DBF file as dictionaries."""
         if path.lower().endswith(".dbf"):
-            table = DBF(path, encoding="cp932")
+            table = DBF(path, encoding=self.encoding)
             for rec in table:
                 yield {k: (str(v) if v is not None else "") for k, v in rec.items()}
         else:
-            with open(path, encoding="cp932", newline="") as f:
+            with open(path, encoding=self.encoding, newline="") as f:
                 reader = csv.DictReader(f)
                 for row in reader:
                     yield row

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,7 +18,7 @@ def test_get_sub_area_id():
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = Path(tmpdir) / 'out.db'
         with Database(db_path) as db:
-            importer = R2KAImporter(db)
+            importer = R2KAImporter(db, encoding="cp932")
             importer.import_csvs([str(dbf_path)])
 
             selector = SubAreaIdSelector(db)
@@ -46,7 +46,7 @@ def test_get_city_id():
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = Path(tmpdir) / 'out.db'
         with Database(db_path) as db:
-            importer = R2KAImporter(db)
+            importer = R2KAImporter(db, encoding="cp932")
             importer.import_csvs([str(dbf_path)])
 
             selector = CityIdSelector(db)
@@ -72,7 +72,7 @@ def test_sub_area_reader():
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = Path(tmpdir) / 'out.db'
         with Database(db_path) as db:
-            importer = R2KAImporter(db)
+            importer = R2KAImporter(db, encoding="cp932")
             importer.import_csvs([str(dbf_path)])
 
             reader = SubAreaReader(db)
@@ -90,7 +90,7 @@ def test_codes_view_reader():
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = Path(tmpdir) / 'out.db'
         with Database(db_path) as db:
-            importer = R2KAImporter(db)
+            importer = R2KAImporter(db, encoding="cp932")
             importer.import_csvs([str(dbf_path)])
 
             reader = CodesViewReader(db)

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -13,7 +13,7 @@ class TestR2KAImporterIntegration(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = Path(tmpdir) / 'out.db'
             with Database(db_path) as db:
-                importer = R2KAImporter(db)
+                importer = R2KAImporter(db, encoding="cp932")
                 attempted, inserted = importer.import_csvs([str(dbf_path)])
                 self.assertTrue(db_path.exists(), 'Database file should be created')
                 self.assertGreater(attempted, 0)
@@ -41,7 +41,7 @@ class TestR2KAImporterIntegration(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = Path(tmpdir) / 'out.db'
             with Database(db_path) as db:
-                importer = R2KAImporter(db)
+                importer = R2KAImporter(db, encoding="cp932")
                 importer.import_csvs([str(dbf_path)])
                 conn = db.conn
                 cur = conn.cursor()


### PR DESCRIPTION
## Summary
- enable custom text encoding for `R2KAImporter`
- add `--encoding` CLI option to `import_r2ka.py`
- document encoding argument in README files
- update tests for explicit encoding

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685413821974832bb953bacb67f7dc62