### PR TITLE
Ensure codes_view is created

### DIFF
--- a/app/build_database.py
+++ b/app/build_database.py
@@ -9,6 +9,7 @@ import os
 sys.path.append(os.path.join(os.path.dirname(__file__), '../'))
 
 from estat_shp_utils.csv_to_sqlite import CsvToSqliteConverter
+from estat_shp_utils.database import create_codes_view, Database
 
 
 def parse_args() -> argparse.Namespace:
@@ -22,6 +23,9 @@ def main() -> None:
     args = parse_args()
     converter = CsvToSqliteConverter(csv_dir=str(args.csv_dir), db_path=str(args.db_path))
     converter.convert()
+    # Create view if the required tables exist
+    with Database(args.db_path) as db:
+        create_codes_view(db.conn)
     print(f"Database saved to {args.db_path}")
 
 

--- a/app/import_r2ka.py
+++ b/app/import_r2ka.py
@@ -9,7 +9,7 @@ import os
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '../'))
 
-from estat_shp_utils.database import Database
+from estat_shp_utils.database import Database, create_codes_view
 from estat_shp_utils.r2ka_importer import R2KAImporter
 
 
@@ -45,6 +45,7 @@ def main() -> None:
         except ValueError as e:
             print(e)
             sys.exit(1)
+        create_codes_view(db.conn)
         print(f"Processed {attempted} rows, inserted {inserted} new records.")
         print(f"Database saved to {args.db_path}")
 

--- a/estat_shp_utils/__init__.py
+++ b/estat_shp_utils/__init__.py
@@ -1,5 +1,5 @@
 from .csv_to_sqlite import CsvToSqliteConverter, read_csv_files, save_to_sqlite
-from .database import Database
+from .database import Database, create_codes_view
 from .r2ka_api import (
     get_city_id,
     get_sub_area_id,
@@ -15,6 +15,7 @@ __all__ = [
     "read_csv_files",
     "save_to_sqlite",
     "Database",
+    "create_codes_view",
     "get_city_id",
     "get_sub_area_id",
     "CityIdSelector",

--- a/estat_shp_utils/database.py
+++ b/estat_shp_utils/database.py
@@ -4,6 +4,37 @@ import sqlite3
 from pathlib import Path
 
 
+def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
+    """Return True if the given table exists."""
+    cur = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        (name,),
+    )
+    return cur.fetchone() is not None
+
+
+def create_codes_view(conn: sqlite3.Connection) -> None:
+    """Create ``codes_view`` if required tables are present."""
+    required = ['prefectures', 'cities', 'sub_areas']
+    if not all(_table_exists(conn, t) for t in required):
+        return
+    conn.execute(
+        """
+        CREATE VIEW IF NOT EXISTS codes_view AS
+        SELECT
+            sa.sub_area_id AS sub_area_id,
+            p.pref_code AS prefecture_code,
+            c.city_code AS city_code,
+            sa.s_area_code AS s_area_code,
+            ((p.pref_code * 1000 + c.city_code) * 1000000 + sa.s_area_code) AS jis_code
+        FROM sub_areas sa
+        JOIN cities c ON sa.city_id = c.city_id
+        JOIN prefectures p ON sa.prefecture_id = p.prefecture_id
+        """
+    )
+    conn.commit()
+
+
 class Database:
     """Simple wrapper around :class:`sqlite3.Connection`."""
 
@@ -22,4 +53,4 @@ class Database:
         self.close()
 
 
-__all__ = ["Database"]
+__all__ = ["Database", "create_codes_view"]

--- a/estat_shp_utils/r2ka_importer.py
+++ b/estat_shp_utils/r2ka_importer.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 
 import csv
 from dbfread import DBF
-from .database import Database
+from .database import Database, create_codes_view
 
 
 class R2KAImporter:
@@ -70,21 +70,7 @@ class R2KAImporter:
         )
         conn.commit()
 
-        cur.execute(
-            """
-            CREATE VIEW IF NOT EXISTS codes_view AS
-            SELECT
-                sa.sub_area_id AS sub_area_id,
-                p.pref_code AS prefecture_code,
-                c.city_code AS city_code,
-                sa.s_area_code AS s_area_code,
-                ((p.pref_code * 1000 + c.city_code) * 1000000 + sa.s_area_code) AS jis_code
-            FROM sub_areas sa
-            JOIN cities c ON sa.city_id = c.city_id
-            JOIN prefectures p ON sa.prefecture_id = p.prefecture_id
-            """
-        )
-        conn.commit()
+        create_codes_view(conn)
 
     def _parse_numeric_code(self, value: str, length: int) -> int:
         """Validate and convert a zero padded numeric code to int."""


### PR DESCRIPTION
## Summary
- add helper to create codes_view in database module
- hook create_codes_view into R2KA importer
- call create_codes_view from import_r2ka and build_database scripts
- export create_codes_view in package

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b210a714832b82f2edbee2f092fe